### PR TITLE
Add dependency on "unstable-lib"

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang setup/infotab
 
 (define collection 'multi)
-(define deps '("base" "scribble-lib"))
+(define deps '("base" "scribble-lib" "unstable-lib"))
 (define build-deps '("racket-doc"))
 
 ; vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Since `unstable/sandbox` is no longer provided by "scribble-lib", add the relevant dependency. Unlike #3, this is fully backwards compatible.
